### PR TITLE
fix(codebuild): detect branch names

### DIFF
--- a/lib/codebuild.js
+++ b/lib/codebuild.js
@@ -1,6 +1,16 @@
+const execa = require('execa');
 const git = require('./git');
 
 // https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
+
+function branchForHEAD() {
+	try {
+		const branches = execa.sync('git', ['branch', '-a', '--contains', 'HEAD']).stdout;
+		return branches.split('\n')[0].split(' ')[1];
+	} catch (err) {
+		return undefined;
+	}
+}
 
 module.exports = {
 	detect() {
@@ -12,7 +22,7 @@ module.exports = {
 			service: 'codebuild',
 			commit: git.head(),
 			build: process.env.CODEBUILD_BUILD_ID,
-			branch: git.branch(),
+			branch: branchForHEAD(),
 			buildUrl: `https://console.aws.amazon.com/codebuild/home?region=${process.env.AWS_REGION}#/builds/${
 				process.env.CODEBUILD_BUILD_ID
 			}/view/new`,

--- a/lib/codebuild.js
+++ b/lib/codebuild.js
@@ -6,7 +6,7 @@ const git = require('./git');
 function branchForHEAD() {
 	try {
 		const branches = execa.sync('git', ['branch', '-a', '--contains', 'HEAD']).stdout;
-		return branches.split('\n')[1];
+		return branches.split('\n')[1].trim();
 	} catch (err) {
 		return undefined;
 	}

--- a/lib/codebuild.js
+++ b/lib/codebuild.js
@@ -6,7 +6,7 @@ const git = require('./git');
 function branchForHEAD() {
 	try {
 		const branches = execa.sync('git', ['branch', '-a', '--contains', 'HEAD']).stdout;
-		return branches.split('\n')[0].split(' ')[1];
+		return branches.split('\n')[1];
 	} catch (err) {
 		return undefined;
 	}

--- a/test/codebuild.test.js
+++ b/test/codebuild.test.js
@@ -25,7 +25,7 @@ test('Push', async t => {
 		service: 'codebuild',
 		commit,
 		build: 'env-ci:40cc72d2-acd5-46f4-a86b-6a3dcd2a39a0',
-		branch: 'master',
+		branch: undefined, // Branch detection only works on CodeBuild
 		buildUrl:
 			'https://console.aws.amazon.com/codebuild/home?region=us-east-1#/builds/env-ci:40cc72d2-acd5-46f4-a86b-6a3dcd2a39a0/view/new',
 		root: '/codebuild/output/src807365521/src/github.com/owner/repo',


### PR DESCRIPTION
It turned out that the branch name detection does not work on CodeBuild. The current version yields head.

This change adds a custom solution for CodeBuild which correctly detects the branch.

If have it running using [this patched version of semantic-release](https://github.com/nRFCloud/semantic-release/commit/56011b1e3ed92b6d989669c13d838128db6a7dcd).

I have verified that it works using a private project:

```

[Container] 2018/04/18 23:15:42 Running command npx semantic-release
[Semantic release]: Running semantic-release version 0.0.0-development
[Semantic release]: Load plugin verifyConditions from @semantic-release/npm
[Semantic release]: Load plugin verifyConditions from @semantic-release/github
[Semantic release]: Load plugin analyzeCommits from @semantic-release/commit-analyzer
[Semantic release]: Load plugin generateNotes from @semantic-release/release-notes-generator
[Semantic release]: Load plugin prepare from @semantic-release/npm
[Semantic release]: Load plugin publish from @semantic-release/npm
[Semantic release]: Load plugin publish from @semantic-release/github
[Semantic release]: Load plugin success from @semantic-release/github
[Semantic release]: Load plugin fail from @semantic-release/github
[Semantic release]: Run automated release from branch saga
[Semantic release]: Call plugin verify-conditions
[Semantic release]: Verify authentication for registry https://registry.npmjs.org/
[Semantic release]: Verify GitHub authentication
[Semantic release]: No git tag version found
[Semantic release]: No previous release found, retrieving all commits
[Semantic release]: Found 1 commits since last release
[Semantic release]: Call plugin analyze-commits
[Semantic release]: Analyzing commit: build(release): use patched version of env-ci
[Semantic release]: The commit should not trigger a release
[Semantic release]: Analysis of 1 commits complete: no release
[Semantic release]: There are no relevant changes, so no new version is released.

[Container] 2018/04/18 23:15:44 Phase complete: POST_BUILD Success: true
[Container] 2018/04/18 23:15:44 Phase context status code: Message: 

```

_Note: we are using a custom branch name there: saga_

