### PR TITLE
fix: fix regex for parsing git branch

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -19,7 +19,7 @@ function branch() {
 	try {
 		const branch = execa
 			.sync('git', ['show', '-s', '--pretty=%d', 'HEAD'])
-			.stdout.match(/\(?(.*)\)?/)[1]
+			.stdout.replace(/^\(|\)$/g, '')
 			.split(', ')
 			.find(branch => branch.startsWith('origin/'));
 


### PR DESCRIPTION
In certain cases the trailing `)` produced by `git show -s --pretty=%d HEAD` was kept in the branch name.