### PR TITLE
fix(git): do not match trailing parenthesis

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -23,7 +23,7 @@ function branch() {
 			.split(', ')
 			.find(branch => branch.startsWith('origin/'));
 
-		return branch ? branch.match(/^origin\/(.+)/)[1] : execa.sync('git', ['rev-parse', '--abbrev-ref', 'HEAD']).stdout;
+		return branch ? branch.match(/^origin\/([^)]+)/)[1] : execa.sync('git', ['rev-parse', '--abbrev-ref', 'HEAD']).stdout;
 	} catch (err) {
 		return undefined;
 	}


### PR DESCRIPTION
```
% git show -s --pretty=%d HEAD
 (HEAD -> origin/greenkeeper/initial)
```

in this case `branch` becomes `greenkeeper/initial)`

This change fixes this.