### PR TITLE
fix: support circle 2.0 env vars

### DIFF
--- a/lib/circleci.js
+++ b/lib/circleci.js
@@ -7,7 +7,8 @@ module.exports = {
 	},
 	configuration() {
 		// Support both 1.0 and 2.0
-		const pullRequest = process.env.CIRCLE_PULL_REQUEST || process.env.CI_PULL_REQUEST;
+		const pullRequestUrl = process.env.CIRCLE_PULL_REQUEST || process.env.CI_PULL_REQUEST;
+		const pullRequest = pullRequestUrl ? pullRequestUrl.split('/').pop() : process.env.CIRCLE_PR_NUMBER;
 		return {
 			name: 'CircleCI',
 			service: 'circleci',
@@ -16,7 +17,7 @@ module.exports = {
 			job: `${process.env.CIRCLE_BUILD_NUM}.${process.env.CIRCLE_NODE_INDEX}`,
 			commit: process.env.CIRCLE_SHA1,
 			branch: process.env.CIRCLE_BRANCH,
-			pr: pullRequest ? pullRequest.split('/').pop() : undefined,
+			pr: pullRequest,
 			isPr: Boolean(pullRequest),
 			slug: `${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}`,
 		};

--- a/lib/circleci.js
+++ b/lib/circleci.js
@@ -1,10 +1,13 @@
-// https://circleci.com/docs/1.0/environment-variables
+// Circle 1.0 docs: https://circleci.com/docs/1.0/environment-variables
+// Circle 2.0 docs: https://circleci.com/docs/2.0/env-vars/
 
 module.exports = {
 	detect() {
 		return Boolean(process.env.CIRCLECI);
 	},
 	configuration() {
+		// Support both 1.0 and 2.0
+		const pullRequest = process.env.CIRCLE_PULL_REQUEST || process.env.CI_PULL_REQUEST;
 		return {
 			name: 'CircleCI',
 			service: 'circleci',
@@ -13,8 +16,8 @@ module.exports = {
 			job: `${process.env.CIRCLE_BUILD_NUM}.${process.env.CIRCLE_NODE_INDEX}`,
 			commit: process.env.CIRCLE_SHA1,
 			branch: process.env.CIRCLE_BRANCH,
-			pr: process.env.CI_PULL_REQUEST ? process.env.CI_PULL_REQUEST.split('/').pop() : undefined,
-			isPr: Boolean(process.env.CI_PULL_REQUEST),
+			pr: pullRequest ? pullRequest.split('/').pop() : undefined,
+			isPr: Boolean(pullRequest),
 			slug: `${process.env.CIRCLE_PROJECT_USERNAME}/${process.env.CIRCLE_PROJECT_REPONAME}`,
 		};
 	},

--- a/test/circleci.test.js
+++ b/test/circleci.test.js
@@ -26,7 +26,7 @@ test('Push', t => {
 	});
 });
 
-test('PR', t => {
+test('PR 1.0', t => {
 	process.env.CIRCLECI = 'true';
 	process.env.CIRCLE_BUILD_NUM = '1234';
 	process.env.CIRCLE_SHA1 = '5678';
@@ -35,6 +35,31 @@ test('PR', t => {
 	process.env.CIRCLE_PROJECT_USERNAME = 'owner';
 	process.env.CIRCLE_PROJECT_REPONAME = 'repo';
 	process.env.CI_PULL_REQUEST = 'uri/pr/10';
+
+	t.deepEqual(circle.configuration(), {
+		name: 'CircleCI',
+		service: 'circleci',
+		commit: '5678',
+		build: '1234',
+		buildUrl: 'https://server.com/buildresult',
+		job: '1234.1',
+		branch: 'pr_branch',
+		pr: '10',
+		isPr: true,
+		slug: 'owner/repo',
+	});
+});
+
+test('PR 2.0', t => {
+	process.env.CIRCLECI = 'true';
+	process.env.CIRCLE_BUILD_NUM = '1234';
+	process.env.CIRCLE_SHA1 = '5678';
+	process.env.CIRCLE_BRANCH = 'pr_branch';
+	process.env.CIRCLE_NODE_INDEX = '1';
+	process.env.CIRCLE_PROJECT_USERNAME = 'owner';
+	process.env.CIRCLE_PROJECT_REPONAME = 'repo';
+	process.env.CIRCLE_PULL_REQUEST = 'uri/pr/10';
+	delete process.env.CI_PULL_REQUEST;
 
 	t.deepEqual(circle.configuration(), {
 		name: 'CircleCI',

--- a/test/circleci.test.js
+++ b/test/circleci.test.js
@@ -74,3 +74,29 @@ test('PR 2.0', t => {
 		slug: 'owner/repo',
 	});
 });
+
+test('PR 2.0 without pull uri', t => {
+	process.env.CIRCLECI = 'true';
+	process.env.CIRCLE_BUILD_NUM = '1234';
+	process.env.CIRCLE_SHA1 = '5678';
+	process.env.CIRCLE_BRANCH = 'pr_branch';
+	process.env.CIRCLE_NODE_INDEX = '1';
+	process.env.CIRCLE_PROJECT_USERNAME = 'owner';
+	process.env.CIRCLE_PROJECT_REPONAME = 'repo';
+	process.env.CIRCLE_PR_NUMBER = '10';
+	delete process.env.CIRCLE_PULL_REQUEST;
+	delete process.env.CI_PULL_REQUEST;
+
+	t.deepEqual(circle.configuration(), {
+		name: 'CircleCI',
+		service: 'circleci',
+		commit: '5678',
+		build: '1234',
+		buildUrl: 'https://server.com/buildresult',
+		job: '1234.1',
+		branch: 'pr_branch',
+		pr: '10',
+		isPr: true,
+		slug: 'owner/repo',
+	});
+});


### PR DESCRIPTION
Circle has deprecated the `CI_PULL_REQUEST` environment variable and it is not available in 2.0 builds. This PR gives support to both 1.0 and 2.0 in this regard.

See <https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables>