### PR TITLE
feat: add fallback environment variable

### DIFF
--- a/lib/codebuild.js
+++ b/lib/codebuild.js
@@ -12,7 +12,7 @@ module.exports = {
 			service: 'codebuild',
 			commit: git.head(),
 			build: process.env.CODEBUILD_BUILD_ID,
-			branch: git.branch(),
+			branch: process.env.GIT_BRANCH || git.branch(),
 			buildUrl: `https://console.aws.amazon.com/codebuild/home?region=${process.env.AWS_REGION}#/builds/${
 				process.env.CODEBUILD_BUILD_ID
 			}/view/new`,


### PR DESCRIPTION
Having problems that `git.branch()` returns `undefined` when executing [semantic-release line 47](https://github.com/semantic-release/semantic-release/blob/a94e08de9aaf678fba1562d0a6c36cfa8093f676/index.js#L47) from codebuild.

Added the possibility to add branch with the help of a environment variable.