### PR TITLE
Feature/support semaphore 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "execa": "^1.0.0",
+    "git-url-parse": "^11.1.2",
     "java-properties": "^0.2.9"
   },
   "devDependencies": {

--- a/services/semaphore.js
+++ b/services/semaphore.js
@@ -1,3 +1,4 @@
+const parseGitUrl = require('git-url-parse');
 const {head} = require('../lib/git');
 
 // https://semaphoreci.com/docs/available-environment-variables.html
@@ -7,20 +8,41 @@ module.exports = {
 		return Boolean(env.SEMAPHORE);
 	},
 	configuration({env, cwd}) {
-		const pr = env.PULL_REQUEST_NUMBER;
-		const isPr = Boolean(pr);
+		if (env.BRANCH_NAME) {
+			// Exists in v1 only
+			const pr = env.PULL_REQUEST_NUMBER;
+			const isPr = Boolean(pr);
+			return {
+				name: 'Semaphore',
+				service: 'semaphore',
+				commit: head({env, cwd}),
+				build: env.SEMAPHORE_BUILD_NUMBER,
+				branch: isPr ? undefined : env.BRANCH_NAME,
+				pr,
+				isPr,
+				prBranch: isPr ? env.BRANCH_NAME : undefined,
+				slug: env.SEMAPHORE_REPO_SLUG,
+				root: env.SEMAPHORE_PROJECT_DIR,
+			};
+		}
 
+		let parsedRepo;
+
+		try {
+			parsedRepo = parseGitUrl(env.SEMAPHORE_GIT_URL || '');
+		} catch (error) {
+			console.log(error);
+		}
+
+		// V2
 		return {
 			name: 'Semaphore',
 			service: 'semaphore',
-			commit: head({env, cwd}),
-			build: env.SEMAPHORE_BUILD_NUMBER,
-			branch: isPr ? undefined : env.BRANCH_NAME,
-			pr,
-			isPr,
-			prBranch: isPr ? env.BRANCH_NAME : undefined,
-			slug: env.SEMAPHORE_REPO_SLUG,
-			root: env.SEMAPHORE_PROJECT_DIR,
+			build: env.SEMAPHORE_WORKFLOW_ID,
+			branch: env.SEMAPHORE_GIT_BRANCH,
+			job: env.SEMAPHORE_JOB_ID,
+			commit: env.SEMAPHORE_GIT_SHA,
+			slug: parsedRepo ? parsedRepo.owner + '/' + parsedRepo.name : undefined,
 		};
 	},
 };

--- a/test/services/semaphore.test.js
+++ b/test/services/semaphore.test.js
@@ -2,7 +2,7 @@ import test from 'ava';
 import semaphore from '../../services/semaphore';
 import {gitRepo, gitCommit} from '../helpers/git-utils';
 
-const env = {
+const env1 = {
 	SEMAPHORE: 'true',
 	SEMAPHORE_BUILD_NUMBER: '91011',
 	BRANCH_NAME: 'master',
@@ -10,11 +10,20 @@ const env = {
 	SEMAPHORE_REPO_SLUG: 'owner/repo',
 };
 
-test('Push', async t => {
+const env2 = {
+	SEMAPHORE: 'true',
+	SEMAPHORE_WORKFLOW_ID: '91011',
+	SEMAPHORE_GIT_BRANCH: 'master',
+	SEMAPHORE_GIT_SHA: '987',
+	SEMAPHORE_GIT_URL: 'git@github.com:owner/repo.git',
+	SEMAPHORE_JOB_ID: '123',
+};
+
+test('Push 1.0', async t => {
 	const {cwd} = await gitRepo(true);
 	const commit = await gitCommit('Test commit message', {cwd});
 
-	t.deepEqual(semaphore.configuration({env, cwd}), {
+	t.deepEqual(semaphore.configuration({env: env1, cwd}), {
 		name: 'Semaphore',
 		service: 'semaphore',
 		commit,
@@ -28,12 +37,12 @@ test('Push', async t => {
 	});
 });
 
-test('PR', async t => {
+test('PR 1.0', async t => {
 	const {cwd} = await gitRepo(true);
 	const commit = await gitCommit('Test commit message', {cwd});
 
 	t.deepEqual(
-		semaphore.configuration({env: Object.assign({}, env, {PULL_REQUEST_NUMBER: '10', BRANCH_NAME: 'pr-branch'}), cwd}),
+		semaphore.configuration({env: Object.assign({}, env1, {PULL_REQUEST_NUMBER: '10', BRANCH_NAME: 'pr-branch'}), cwd}),
 		{
 			name: 'Semaphore',
 			service: 'semaphore',
@@ -47,4 +56,32 @@ test('PR', async t => {
 			slug: 'owner/repo',
 		}
 	);
+});
+
+test('Push 2.0', async t => {
+	const {cwd} = await gitRepo(true);
+
+	t.deepEqual(semaphore.configuration({env: env2, cwd}), {
+		name: 'Semaphore',
+		service: 'semaphore',
+		commit: '987',
+		build: '91011',
+		branch: 'master',
+		slug: 'owner/repo',
+		job: '123',
+	});
+});
+
+test('PR 2.0', async t => {
+	const {cwd} = await gitRepo(true);
+
+	t.deepEqual(semaphore.configuration({env: env2, cwd}), {
+		name: 'Semaphore',
+		service: 'semaphore',
+		commit: '987',
+		build: '91011',
+		branch: 'master',
+		slug: 'owner/repo',
+		job: '123',
+	});
 });


### PR DESCRIPTION
Related to issue: https://github.com/pvdlg/env-ci/issues/73

Adds support for Semaphore 2. I have tested and confirmed the presence of all the needed environment variables in my semaphore 2 environment (both PR / not PR)

- Some of the variables are no longer supported in Semaphore 2. Mostly PR related variables, due to the lack of supporting environment variables
- Some new variables are supported compared to semaphore 1 :tada: 
- Had to pull in `git-url-parse` to produce the `slug`, since SEMAPHORE_REPO_SLUG does not exist anymore. The only option is now to parse `SEMAPHORE_GIT_URL`
- Note the try / catch in semaphore.js: I put that in to prevent the index.spec.ts test from failing. I believe the conditions set by this test will not exist in real usecases.