### PR TITLE
feat(teamcity): allow anyone to set build from env

### DIFF
--- a/services/teamcity.js
+++ b/services/teamcity.js
@@ -27,7 +27,7 @@ const getProperties = ({env, cwd}) => {
 					(key === 'branch' ? env.TEAMCITY_BUILD_BRANCH : undefined) ||
 					(buildProperties ? buildProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
 					(configProperties ? configProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
-					(key === 'branch' ? branch({env, cwd,}) : undefined)
+					(key === 'branch' ? branch({env, cwd}) : undefined),
 			}),
 		{}
 	);

--- a/services/teamcity.js
+++ b/services/teamcity.js
@@ -27,6 +27,7 @@ const getProperties = ({env, cwd}) => {
 					(buildProperties ? buildProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
 					(configProperties ? configProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
 					(key === 'branch' ? branch({env, cwd}) : undefined),
+					(key === 'branch' ? env.TEAMCITY_BUILD_BRANCH : undefined)
 			}),
 		{}
 	);

--- a/services/teamcity.js
+++ b/services/teamcity.js
@@ -24,10 +24,10 @@ const getProperties = ({env, cwd}) => {
 		(result, key) =>
 			Object.assign(result, {
 				[key]:
+					(key === 'branch' ? env.TEAMCITY_BUILD_BRANCH : undefined) ||
 					(buildProperties ? buildProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
 					(configProperties ? configProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
-					(key === 'branch' ? branch({env, cwd}) : undefined) ||
-					(key === 'branch' ? env.TEAMCITY_BUILD_BRANCH : undefined)
+					(key === 'branch' ? branch({env, cwd}) : undefined)
 			}),
 		{}
 	);

--- a/services/teamcity.js
+++ b/services/teamcity.js
@@ -27,7 +27,7 @@ const getProperties = ({env, cwd}) => {
 					(key === 'branch' ? env.TEAMCITY_BUILD_BRANCH : undefined) ||
 					(buildProperties ? buildProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
 					(configProperties ? configProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
-					(key === 'branch' ? branch({env, cwd}) : undefined)
+					(key === 'branch' ? branch({env, cwd,}) : undefined)
 			}),
 		{}
 	);

--- a/services/teamcity.js
+++ b/services/teamcity.js
@@ -26,7 +26,7 @@ const getProperties = ({env, cwd}) => {
 				[key]:
 					(buildProperties ? buildProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
 					(configProperties ? configProperties.get(PROPERTIES_MAPPING[key]) : undefined) ||
-					(key === 'branch' ? branch({env, cwd}) : undefined),
+					(key === 'branch' ? branch({env, cwd}) : undefined) ||
 					(key === 'branch' ? env.TEAMCITY_BUILD_BRANCH : undefined)
 			}),
 		{}


### PR DESCRIPTION
In my case, env-ci isn't able to detect branch, but I can set it using a parameter to a env variable, it'll be quite simple, this change shouldn't break anything and should help a lot of people :)