### PR TITLE
fix(github): fix issue with branch on pull request

### DIFF
--- a/services/github.js
+++ b/services/github.js
@@ -1,6 +1,6 @@
 // https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
 
-const parseBranch = branch => (/refs\/heads\/(.*)/i.exec(branch) || [])[1];
+const parseBranch = branch => (/(refs\/heads\/)?(.*)/i.exec(branch) || [])[2];
 
 const getPrEvent = ({env}) => {
 	try {
@@ -16,7 +16,7 @@ const getPrEvent = ({env}) => {
 		// Noop
 	}
 
-	return {pr: undefined, branch: undefined};
+	return {};
 };
 
 module.exports = {


### PR DESCRIPTION
Base ref may contains something like `master` and not `refs/heads/master`, so adjust regex to take care about this.

When an error occurred in `getPrEvent` returns an empty object to avoid to erase all previously sets