### PR TITLE
fix: GitHub actions branch regex to match long names again

### DIFF
--- a/services/github.js
+++ b/services/github.js
@@ -1,6 +1,6 @@
 // https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
 
-const parseBranch = branch => (/^(?:\/refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
+const parseBranch = branch => (/^(?:refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
 
 const getPrEvent = ({env}) => {
 	try {

--- a/test/services/github.test.js
+++ b/test/services/github.test.js
@@ -8,7 +8,7 @@ import github from '../../services/github';
 const env = {
 	GITHUB_ACTION: 'action-name',
 	GITHUB_SHA: '1234',
-	GITHUB_REF: '/refs/heads/master',
+	GITHUB_REF: 'refs/heads/master',
 	GITHUB_REPOSITORY: 'owner/repo',
 	GITHUB_WORKSPACE: '/workspace',
 };
@@ -41,7 +41,7 @@ test('Push - with short branch name', t => {
 
 test('PR - with event.json file', t => {
 	const eventFile = tempy.file({extension: 'json'});
-	const event = {pull_request: {number: '10', base: {ref: '/refs/heads/master'}}};
+	const event = {pull_request: {number: '10', base: {ref: 'refs/heads/master'}}};
 	fs.writeFileSync(eventFile, JSON.stringify(event));
 
 	t.deepEqual(
@@ -49,7 +49,7 @@ test('PR - with event.json file', t => {
 			env: {
 				...env,
 				GITHUB_EVENT_NAME: 'pull_request',
-				GITHUB_REF: '/refs/heads/pr-branch',
+				GITHUB_REF: 'refs/heads/pr-branch',
 				GITHUB_EVENT_PATH: eventFile,
 			},
 		}),
@@ -77,7 +77,7 @@ test('PR - with event.json file and short branch name', t => {
 			env: {
 				...env,
 				GITHUB_EVENT_NAME: 'pull_request',
-				GITHUB_REF: '/refs/heads/pr-branch',
+				GITHUB_REF: 'refs/heads/pr-branch',
 				GITHUB_EVENT_PATH: eventFile,
 			},
 		}),
@@ -101,7 +101,7 @@ test('PR - with missing event.json file', t => {
 			env: {
 				...env,
 				GITHUB_EVENT_NAME: 'pull_request',
-				GITHUB_REF: '/refs/heads/pr-branch',
+				GITHUB_REF: 'refs/heads/pr-branch',
 				GITHUB_EVENT_PATH: '/tmp/null',
 			},
 		}),
@@ -122,7 +122,7 @@ test('PR - with missing event.json file', t => {
 test('PR - with missing event.json file path', t => {
 	t.deepEqual(
 		github.configuration({
-			env: {...env, GITHUB_EVENT_NAME: 'pull_request', GITHUB_REF: '/refs/heads/pr-branch'},
+			env: {...env, GITHUB_EVENT_NAME: 'pull_request', GITHUB_REF: 'refs/heads/pr-branch'},
 		}),
 		{
 			name: 'GitHub Actions',
@@ -148,7 +148,7 @@ test('PR - with missing "pull_request" in event.json file', t => {
 			env: {
 				...env,
 				GITHUB_EVENT_NAME: 'pull_request',
-				GITHUB_REF: '/refs/heads/pr-branch',
+				GITHUB_REF: 'refs/heads/pr-branch',
 				GITHUB_EVENT_PATH: eventFile,
 			},
 		}),
@@ -176,7 +176,7 @@ test('PR - with missing "pull_request.base" in event.json file', t => {
 			env: {
 				...env,
 				GITHUB_EVENT_NAME: 'pull_request',
-				GITHUB_REF: '/refs/heads/pr-branch',
+				GITHUB_REF: 'refs/heads/pr-branch',
 				GITHUB_EVENT_PATH: eventFile,
 			},
 		}),
@@ -196,7 +196,7 @@ test('PR - with missing "pull_request.base" in event.json file', t => {
 
 test('PR - with erronous branch names', t => {
 	const eventFile = tempy.file({extension: 'json'});
-	const event = {pull_request: {number: '10', base: {ref: '/refs/tags/master'}}};
+	const event = {pull_request: {number: '10', base: {ref: 'refs/tags/master'}}};
 	fs.writeFileSync(eventFile, JSON.stringify(event));
 
 	t.deepEqual(
@@ -204,7 +204,7 @@ test('PR - with erronous branch names', t => {
 			env: {
 				...env,
 				GITHUB_EVENT_NAME: 'pull_request',
-				GITHUB_REF: '/refs/tags/pr-branch',
+				GITHUB_REF: 'refs/tags/pr-branch',
 				GITHUB_EVENT_PATH: eventFile,
 			},
 		}),


### PR DESCRIPTION
After this [PR](https://github.com/pvdlg/env-ci/commit/bc0e7bd56deb7aa6d75525f58829a6302148dde6), the branch name for GitHub workflow is `undefined`

The tests are written to match against **/refs/heads/pr-branch**, but the documentation describes the GITHUB_REF to have the pattern **refs/heads/pr-branch**

https://help.github.com/en/articles/virtual-environments-for-github-actions#default-environment-variables