### PR TITLE
fix: GitHub ref may have no leading slash

### DIFF
--- a/services/github.js
+++ b/services/github.js
@@ -1,6 +1,6 @@
 // https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
 
-const parseBranch = branch => (/^(?:\/refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
+const parseBranch = branch => (/^(?:\/?refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
 
 const getPrEvent = ({env}) => {
 	try {

--- a/test/services/github.test.js
+++ b/test/services/github.test.js
@@ -221,3 +221,16 @@ test('PR - with erronous branch names', t => {
 		}
 	);
 });
+
+test('Push - with no leading slash', t => {
+	t.deepEqual(github.configuration({env: {...env, GITHUB_REF: 'refs/heads/saga'}}), {
+		name: 'GitHub Actions',
+		service: 'github',
+		commit: '1234',
+		branch: 'saga',
+		isPr: false,
+		prBranch: undefined,
+		root: '/workspace',
+		slug: 'owner/repo',
+	});
+});


### PR DESCRIPTION
Check the "Semantic Release" step in [this Action run](https://github.com/NordicSemiconductor/modemtalk/commit/e4dfb10a1966c4b19809aa6de4ed106ed8d7c21e/checks):

```
2019-09-27T09:02:17.3889770Z GITHUB_REF=refs/heads/saga
```

That's why semantic release fails later with:

```
This test run was triggered on the branch undefined
```