### PR TITLE
Fixes issue with branch format in github CI

### DIFF
--- a/services/github.js
+++ b/services/github.js
@@ -1,42 +1,45 @@
 // https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
 
+const parseBranchOld = branch => (/refs\/heads\/(.*)/i.exec(branch) || [])[1];
 const parseBranch = branch => (/^(?:\/refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
 
-const getPrEvent = ({env}) => {
-	try {
-		const event = env.GITHUB_EVENT_PATH ? require(env.GITHUB_EVENT_PATH) : undefined;
+const getPrEvent = ({ env }) => {
+  try {
+    const event = env.GITHUB_EVENT_PATH ? require(env.GITHUB_EVENT_PATH) : undefined;
 
-		if (event && event.pull_request) {
-			return {
-				branch: event.pull_request.base ? parseBranch(event.pull_request.base.ref) : undefined,
-				pr: event.pull_request.number,
-			};
-		}
-	} catch (_) {
-		// Noop
-	}
+    if (event && event.pull_request) {
+      console.log(parseBranchOld(event.pull_request.base.ref), parseBranch(event.pull_request.base.ref));
+      return {
+        branch: event.pull_request.base ? parseBranch(event.pull_request.base.ref) : undefined,
+        pr: event.pull_request.number,
+      };
+    }
+  } catch (_) {
+    // Noop
+  }
 
-	return {pr: undefined, branch: undefined};
+  return { pr: undefined, branch: undefined };
 };
 
 module.exports = {
-	detect({env}) {
-		return Boolean(env.GITHUB_ACTION);
-	},
-	configuration({env, cwd}) {
-		const isPr = env.GITHUB_EVENT_NAME === 'pull_request';
-		const branch = parseBranch(env.GITHUB_REF);
+  detect({ env }) {
+    return Boolean(env.GITHUB_ACTION);
+  },
+  configuration({ env, cwd }) {
+    const isPr = env.GITHUB_EVENT_NAME === "pull_request";
+    console.log(parseBranchOld(env.GITHUB_REF), parseBranch(env.GITHUB_REF));
+    const branch = parseBranch(env.GITHUB_REF);
 
-		return {
-			name: 'GitHub Actions',
-			service: 'github',
-			commit: env.GITHUB_SHA,
-			isPr,
-			branch,
-			prBranch: isPr ? branch : undefined,
-			slug: env.GITHUB_REPOSITORY,
-			root: env.GITHUB_WORKSPACE,
-			...(isPr ? getPrEvent({env, cwd}) : undefined),
-		};
-	},
+    return {
+      name: "GitHub Actions",
+      service: "github",
+      commit: env.GITHUB_SHA,
+      isPr,
+      branch,
+      prBranch: isPr ? branch : undefined,
+      slug: env.GITHUB_REPOSITORY,
+      root: env.GITHUB_WORKSPACE,
+      ...(isPr ? getPrEvent({ env, cwd }) : undefined),
+    };
+  },
 };

--- a/services/github.js
+++ b/services/github.js
@@ -1,4 +1,4 @@
-// https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
+// https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
 
 const parseBranch = branch => (/^\/?(?:refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
 

--- a/services/github.js
+++ b/services/github.js
@@ -1,45 +1,42 @@
-// https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
+// https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables
 
-const parseBranchOld = branch => (/refs\/heads\/(.*)/i.exec(branch) || [])[1];
-const parseBranch = branch => (/^(?:\/refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
+const parseBranch = branch => (/^\/?(?:refs\/heads\/)?([^/]+)$/i.exec(branch) || [])[1];
 
-const getPrEvent = ({ env }) => {
-  try {
-    const event = env.GITHUB_EVENT_PATH ? require(env.GITHUB_EVENT_PATH) : undefined;
+const getPrEvent = ({env}) => {
+	try {
+		const event = env.GITHUB_EVENT_PATH ? require(env.GITHUB_EVENT_PATH) : undefined;
 
-    if (event && event.pull_request) {
-      console.log(parseBranchOld(event.pull_request.base.ref), parseBranch(event.pull_request.base.ref));
-      return {
-        branch: event.pull_request.base ? parseBranch(event.pull_request.base.ref) : undefined,
-        pr: event.pull_request.number,
-      };
-    }
-  } catch (_) {
-    // Noop
-  }
+		if (event && event.pull_request) {
+			return {
+				branch: event.pull_request.base ? parseBranch(event.pull_request.base.ref) : undefined,
+				pr: event.pull_request.number,
+			};
+		}
+	} catch (_) {
+		// Noop
+	}
 
-  return { pr: undefined, branch: undefined };
+	return {pr: undefined, branch: undefined};
 };
 
 module.exports = {
-  detect({ env }) {
-    return Boolean(env.GITHUB_ACTION);
-  },
-  configuration({ env, cwd }) {
-    const isPr = env.GITHUB_EVENT_NAME === "pull_request";
-    console.log(parseBranchOld(env.GITHUB_REF), parseBranch(env.GITHUB_REF));
-    const branch = parseBranch(env.GITHUB_REF);
+	detect({env}) {
+		return Boolean(env.GITHUB_ACTION);
+	},
+	configuration({env, cwd}) {
+		const isPr = env.GITHUB_EVENT_NAME === 'pull_request';
+		const branch = parseBranch(env.GITHUB_REF);
 
-    return {
-      name: "GitHub Actions",
-      service: "github",
-      commit: env.GITHUB_SHA,
-      isPr,
-      branch,
-      prBranch: isPr ? branch : undefined,
-      slug: env.GITHUB_REPOSITORY,
-      root: env.GITHUB_WORKSPACE,
-      ...(isPr ? getPrEvent({ env, cwd }) : undefined),
-    };
-  },
+		return {
+			name: 'GitHub Actions',
+			service: 'github',
+			commit: env.GITHUB_SHA,
+			isPr,
+			branch,
+			prBranch: isPr ? branch : undefined,
+			slug: env.GITHUB_REPOSITORY,
+			root: env.GITHUB_WORKSPACE,
+			...(isPr ? getPrEvent({env, cwd}) : undefined),
+		};
+	},
 };

--- a/test/services/github.test.js
+++ b/test/services/github.test.js
@@ -26,6 +26,19 @@ test('Push', t => {
 	});
 });
 
+test('Push to branch without backslash at the beginning', t => {
+	t.deepEqual(github.configuration({env: {...env, GITHUB_REF: 'refs/heads/master'}}), {
+		name: 'GitHub Actions',
+		service: 'github',
+		commit: '1234',
+		branch: 'master',
+		isPr: false,
+		prBranch: undefined,
+		root: '/workspace',
+		slug: 'owner/repo',
+	});
+});
+
 test('Push - with short branch name', t => {
 	t.deepEqual(github.configuration({env: {...env, GITHUB_REF: 'master'}}), {
 		name: 'GitHub Actions',


### PR DESCRIPTION
Branch format in Github Actions seems to be `refs/heads/<branch_name>` but `parseBranch` is expecting a `/` at the beginning.

This PR modifies the Regex expression that parses the branch name, making that `/` optional to support both scenarios. Also a new test is defined to test both cases.