### PR TITLE
Add CircleCI target branch

### DIFF
--- a/services/circleci.js
+++ b/services/circleci.js
@@ -18,7 +18,7 @@ module.exports = {
 			job: `${env.CIRCLE_BUILD_NUM}.${env.CIRCLE_NODE_INDEX}`,
 			commit: env.CIRCLE_SHA1,
 			tag: env.CIRCLE_TAG,
-			branch: isPr ? undefined : env.CIRCLE_BRANCH,
+			branch: isPr ? env.CIRCLE_TARGET_BRANCH : env.CIRCLE_BRANCH,
 			pr,
 			isPr,
 			prBranch: isPr ? env.CIRCLE_BRANCH : undefined,


### PR DESCRIPTION
**Disclaimer: CircleCI currently doesn't provide any information regarding the target branch when you are in a Pull Request.**

This PR uses `CIRCLE_TARGET_BRANCH` environment variable to identify the target branch of a PR instead of explicitly setting it to `undefined`. 

`CIRCLE_TARGET_BRANCH` must be provided by the end-user since CircleCI won't set it, hence, the usual flow won't be impacted.