### PR TITLE
fix(vsts): use `BUILD_SOURCEBRANCH` instead of `BUILD_SOURCEBRANCHNAME`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,4 +2,8 @@ function prNumber(pr) {
 	return (/\d+(?!.*\d+)/.exec(pr) || [])[0];
 }
 
-module.exports = {prNumber};
+function parseBranch(branch) {
+	return branch ? /^(?:refs\/heads\/)?(?<branch>.+)$/i.exec(branch)[1] : undefined;
+}
+
+module.exports = {prNumber, parseBranch};

--- a/services/github.js
+++ b/services/github.js
@@ -1,6 +1,5 @@
 // https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
-
-const parseBranch = branch => (/^(?:refs\/heads\/)?(?<branch>.+)$/i.exec(branch) || [])[1];
+const {parseBranch} = require('../lib/utils');
 
 const getPrEvent = ({env}) => {
 	try {

--- a/services/vsts.js
+++ b/services/vsts.js
@@ -1,5 +1,6 @@
 // https://docs.microsoft.com/en-us/vsts/pipelines/build/variables
 // The docs indicate that SYSTEM_PULLREQUEST_SOURCEBRANCH and SYSTEM_PULLREQUEST_TARGETBRANCH are in the long format (e.g `refs/heads/master`) however tests show they are both in the short format (e.g. `master`)
+const {parseBranch} = require('../lib/utils');
 
 module.exports = {
 	detect({env}) {
@@ -14,10 +15,10 @@ module.exports = {
 			service: 'vsts',
 			commit: env.BUILD_SOURCEVERSION,
 			build: env.BUILD_BUILDNUMBER,
-			branch: isPr ? env.SYSTEM_PULLREQUEST_TARGETBRANCH : env.BUILD_SOURCEBRANCHNAME,
+			branch: parseBranch(isPr ? env.SYSTEM_PULLREQUEST_TARGETBRANCH : env.BUILD_SOURCEBRANCH),
 			pr,
 			isPr,
-			prBranch: isPr ? env.SYSTEM_PULLREQUEST_SOURCEBRANCH : undefined,
+			prBranch: parseBranch(isPr ? env.SYSTEM_PULLREQUEST_SOURCEBRANCH : undefined),
 			root: env.BUILD_REPOSITORY_LOCALPATH,
 		};
 	},

--- a/test/services/vsts.test.js
+++ b/test/services/vsts.test.js
@@ -5,12 +5,26 @@ const env = {
 	BUILD_BUILDURI: 'https://fabrikamfiber.visualstudio.com/_git/Scripts',
 	BUILD_SOURCEVERSION: '5678',
 	BUILD_BUILDNUMBER: '1234',
-	BUILD_SOURCEBRANCHNAME: 'master',
+	BUILD_SOURCEBRANCH: 'master',
 	BUILD_REPOSITORY_LOCALPATH: '/',
 };
 
 test('Push', t => {
 	t.deepEqual(vsts.configuration({env}), {
+		name: 'Visual Studio Team Services',
+		service: 'vsts',
+		commit: '5678',
+		build: '1234',
+		branch: 'master',
+		pr: undefined,
+		isPr: false,
+		prBranch: undefined,
+		root: '/',
+	});
+});
+
+test('Push - with long branch name', t => {
+	t.deepEqual(vsts.configuration({env: {...env, BUILD_SOURCEBRANCH: 'refs/heads/master'}}), {
 		name: 'Visual Studio Team Services',
 		service: 'vsts',
 		commit: '5678',


### PR DESCRIPTION
Fix #121

For some reason VSTS `BUILD_SOURCEBRANCHNAME` contains only the last segment of the branch name, so if the branch is `feature/my-feature` the variable contains `feature`.

Really sounds like a bug, but according to the doc it is intended: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#agent-variables