### PR TITLE
Update jenkins.js

### DIFF
--- a/services/jenkins.js
+++ b/services/jenkins.js
@@ -9,7 +9,7 @@ module.exports = {
   configuration({env, cwd}) {
     const pr = env.ghprbPullId || env.gitlabMergeRequestId || env.CHANGE_ID;
     const isPr = Boolean(pr);
-    const localBranch = env.GIT_LOCAL_BRANCH || env.GIT_BRANCH || env.gitlabBranch || env.BRANCH_NAME;
+    const localBranch = env.GIT_LOCAL_BRANCH || env.CHANGE_BRANCH || env.GIT_BRANCH || env.gitlabBranch || env.BRANCH_NAME;
 
     return {
       name: 'Jenkins',


### PR DESCRIPTION
Trying to use env-ci in a multi-branch pipeline jenkins project. The main problem I have run into is that jenkins will make it's own branch when building (e.g PR-123). This is *not* the name of the actual branch it's building, and anything that tries to use the `branch` name will fail

https://ci.eclipse.org/webtools/env-vars.html/

Solution:

use the `CHANGE_BRANCH` env var

> ### CHANGE_BRANCH
> For a multibranch project corresponding to some kind of change request, this will be set to the name of the actual head on the source control system which may or may not be different from BRANCH_NAME. For example in GitHub or Bitbucket this would have the name of the origin branch whereas BRANCH_NAME would be something like PR-24.

