### PR TITLE
fix: use head ref to determine branch of github action

### DIFF
--- a/services/github.js
+++ b/services/github.js
@@ -1,13 +1,13 @@
 // https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables
-const {parseBranch} = require('../lib/utils');
+const { parseBranch } = require("../lib/utils");
 
-const getPrEvent = ({env}) => {
+const getPrEvent = ({ env }) => {
   try {
     const event = env.GITHUB_EVENT_PATH ? require(env.GITHUB_EVENT_PATH) : undefined;
 
     if (event && event.pull_request) {
       return {
-        branch: event.pull_request.base ? parseBranch(event.pull_request.base.ref) : undefined,
+        branch: event.pull_request.head ? parseBranch(event.pull_request.head.ref) : undefined,
         pr: event.pull_request.number,
       };
     }
@@ -15,27 +15,27 @@ const getPrEvent = ({env}) => {
     // Noop
   }
 
-  return {pr: undefined, branch: undefined};
+  return { pr: undefined, branch: undefined };
 };
 
 module.exports = {
-  detect({env}) {
+  detect({ env }) {
     return Boolean(env.GITHUB_ACTION);
   },
-  configuration({env, cwd}) {
-    const isPr = env.GITHUB_EVENT_NAME === 'pull_request';
+  configuration({ env, cwd }) {
+    const isPr = env.GITHUB_EVENT_NAME === "pull_request";
     const branch = parseBranch(env.GITHUB_REF);
 
     return {
-      name: 'GitHub Actions',
-      service: 'github',
+      name: "GitHub Actions",
+      service: "github",
       commit: env.GITHUB_SHA,
       isPr,
       branch,
       prBranch: isPr ? branch : undefined,
       slug: env.GITHUB_REPOSITORY,
       root: env.GITHUB_WORKSPACE,
-      ...(isPr ? getPrEvent({env, cwd}) : undefined),
+      ...(isPr ? getPrEvent({ env, cwd }) : undefined),
     };
   },
 };


### PR DESCRIPTION
Correct me if I'm wrong. I just spent a couple of hours trying to get a release preview of `semantic-release` working with a GitHub action. This action runs on PR events and should analyze the commits on the branch of the PR. However, `semantic-release` kept claiming that it would run on `master` and not the branch. 

Then I ended up here and saw that you're using `event.pull_request.base` to determine the branch. If I understand the [docs](https://developer.github.com/v3/pulls/) correctly then `base` is the `branch` the PR is targeted to, so not the `branch` of the PR itself. 

I've therefore changed it to `head`. Does this make sense or am I getting something completely wrong? 