### PR TITLE
Add Netlify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ if (isCI) {
 | [GitHub Actions](https://help.github.com/en/articles/virtual-environments-for-github-actions#environment-variables)                    |   `github`    | :white_check_mark: |     :white_check_mark:      | :white_check_mark: |           :x:           |        :x:         |        :x:         |        :x:         |        :x:         |  :white_check_mark:   |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark: | :white_check_mark: |
 | [GitLab CI/CD](https://docs.gitlab.com/ce/ci/variables/README.html)                                                                    |   `gitlab`    | :white_check_mark: |     :white_check_mark:      | :white_check_mark: |   :white_check_mark:    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |  :white_check_mark:   |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark: | :white_check_mark: |
 | [Jenkins](https://wiki.jenkins.io/display/JENKINS/Building+a+software+project)                                                         |   `jenkins`   | :white_check_mark: |    [:warning:](#jenkins)    | :white_check_mark: |           :x:           | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         | [:warning:](#jenkins) | [:warning:](#jenkins) | [:warning:](#jenkins) | :white_check_mark: | :white_check_mark: |
+| [Netlify](https://docs.netlify.com/configure-builds/environment-variables/#netlify-configuration-variables)                            |   `netlify`   | :white_check_mark: |    [:warning:](#netlify)    | :white_check_mark: |           :x:           | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |  :white_check_mark:   |  :white_check_mark:   |  :white_check_mark:   | :white_check_mark: | :white_check_mark: |
 | [Puppet](https://puppet.com/docs/pipelines-for-apps/enterprise/environment-variable.html)                                              |   `puppet`    | :white_check_mark: |     :white_check_mark:      | :white_check_mark: |           :x:           | :white_check_mark: | :white_check_mark: |        :x:         |        :x:         |          :x:          |          :x:          |          :x:          |        :x:         | :white_check_mark: |
 | [Sail CI](https://sail.ci/docs/environment-variables)                                                                                  |    `sail`     | :white_check_mark: |     [:warning:](#sail)      | :white_check_mark: |           :x:           |        :x:         |        :x:         |        :x:         |        :x:         |  :white_check_mark:   |  :white_check_mark:   |          :x:          | :white_check_mark: | :white_check_mark: |
 | [Scrutinizer](https://scrutinizer-ci.com/docs/build/environment-variables)                                                             | `scrutinizer` | :white_check_mark: |     :white_check_mark:      | :white_check_mark: |           :x:           | :white_check_mark: |        :x:         |        :x:         |        :x:         |  :white_check_mark:   |  :white_check_mark:   |  :white_check_mark:   |        :x:         |        :x:         |
@@ -145,16 +146,23 @@ Therefore in the case of Pull Request builds, `env-ci` will not be able to deter
 
 See [feature request](https://discuss.circleci.com/t/create-a-circle-target-branch-envar/10022).
 
-## Jenkins
+### Jenkins
 
 Triggering build when a Pull Request is opened/updated is supported only via the [ghprb-plugin](https://github.com/jenkinsci/ghprb-plugin) and [gitlab-plugin](https://github.com/jenkinsci/gitlab-plugin). Therefore `env-ci` will set `isPr`, `pr` and `prBranch` and define `branch` with the Pull Request target branch only if one those plugin is used.
 
-## Sail
+### Netlify
+
+For builds triggered when a Pull Request is opened/updated, Netlify doesn't provide an environment variable indicating the target branch.
+Therefore in the case of Pull Request builds, `env-ci` will not be able to determine the `branch` property. However `prBranch` will be set.
+
+See [feature request](https://answers.netlify.com/t/access-pr-target-branch-when-deploying-preview-build/32402)
+
+### Sail
 
 For builds triggered when a Pull Request is opened/updated, Sail doesn't provide an environment variable indicating the target branch, and the one for the current branch is set to `pull/<PR number>` independently of the the branch name from which the Pull Request originated.
 Therefore in the case of Pull Request builds, `env-ci` will not be able to determine the `branch` and `prBranch` properties.
 
-## Semaphore
+### Semaphore
 
 For builds triggered when a Pull Request is opened/updated, Semaphore 1.0 doesn't provide an environment variable indicating the target branch.
 Therefore in the case of Pull Request builds, `env-ci` will not be able to determine the `branch` property. However `prBranch` will be set.

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const services = {
   github: require('./services/github'),
   gitlab: require('./services/gitlab'),
   jenkins: require('./services/jenkins'),
+  netlify: require('./services/netlify'),
   puppet: require('./services/puppet'),
   sail: require('./services/sail'),
   scrutinizer: require('./services/scrutinizer'),

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "github",
     "gitlab",
     "jenkins",
+    "netlify",
     "puppet",
     "sail",
     "scrutinizer",

--- a/services/netlify.js
+++ b/services/netlify.js
@@ -1,0 +1,24 @@
+// https://docs.netlify.com/configure-builds/environment-variables/#netlify-configuration-variables
+
+module.exports = {
+  detect({env}) {
+    return env.NETLIFY === 'true';
+  },
+  configuration({env}) {
+    const isPr = env.PULL_REQUEST === 'true';
+
+    return {
+      name: 'Netlify',
+      service: 'netlify',
+      commit: env.COMMIT_REF,
+      build: env.DEPLOY_ID,
+      buildUrl: `https://app.netlify.com/sites/${env.SITE_NAME}/deploys/${env.DEPLOY_ID}`,
+      branch: isPr ? undefined : env.HEAD,
+      pr: env.REVIEW_ID,
+      isPr,
+      prBranch: isPr ? env.HEAD : undefined,
+      slug: (env.REPOSITORY_URL.match(/[^/:]+\/[^/]+?$/) || [])[0],
+      root: env.PWD,
+    };
+  },
+};

--- a/test/services/netlify.test.js
+++ b/test/services/netlify.test.js
@@ -1,0 +1,62 @@
+const test = require('ava');
+const netlify = require('../../services/netlify');
+
+const env = {
+  CI: 'true',
+  NETLIFY: 'true',
+  SITE_NAME: 'website-name',
+  SITE_ID: '37597ed0-087c-4d3e-960f-1d5c8fbac75e',
+  URL: 'https://example.com',
+  COMMIT_REF: '495d988cee629dbf63dca717e0vd1e4f77afd034',
+  HEAD: 'test-page',
+  BRANCH: 'test-page',
+  BUILD_ID: '60106253d15c6600087018ef',
+  DEPLOY_ID: '60106253d13f6600587118d1',
+  DEPLOY_URL: 'https://60106253d13f6600587118d1--website-name.netlify.app',
+  DEPLOY_PRIME_URL: 'https://website-name.netlify.app',
+  REPOSITORY_URL: 'https://github.com/owner/repo',
+  PWD: '/opt/build/repo',
+};
+
+test('Push', t => {
+  t.deepEqual(netlify.configuration({env}), {
+    name: 'Netlify',
+    service: 'netlify',
+    commit: '495d988cee629dbf63dca717e0vd1e4f77afd034',
+    branch: 'test-page',
+    build: '60106253d13f6600587118d1',
+    buildUrl: 'https://app.netlify.com/sites/website-name/deploys/60106253d13f6600587118d1',
+    pr: undefined,
+    isPr: false,
+    prBranch: undefined,
+    slug: 'owner/repo',
+    root: '/opt/build/repo',
+  });
+});
+
+test('PR', t => {
+  t.deepEqual(
+    netlify.configuration({
+      env: {
+        ...env,
+        BRANCH: 'pull/12/head',
+        PULL_REQUEST: 'true',
+        REVIEW_ID: '12',
+        DEPLOY_PRIME_URL: 'https://deploy-preview-12--website-name.netlify.app',
+      },
+    }),
+    {
+      name: 'Netlify',
+      service: 'netlify',
+      commit: '495d988cee629dbf63dca717e0vd1e4f77afd034',
+      branch: undefined,
+      build: '60106253d13f6600587118d1',
+      buildUrl: 'https://app.netlify.com/sites/website-name/deploys/60106253d13f6600587118d1',
+      pr: '12',
+      isPr: true,
+      prBranch: 'test-page',
+      slug: 'owner/repo',
+      root: '/opt/build/repo',
+    }
+  );
+});


### PR DESCRIPTION
Fixes #125

Contrary to #126, this implementation also sets `prBranch`, `slug` and `root`, and unsets `branch` for PR builds (because it points to the source, not target branch. The README is updated accordingly.