### PR TITLE
fix(github): detect `pull_request_target` as pull request build

### DIFF
--- a/services/github.js
+++ b/services/github.js
@@ -23,7 +23,7 @@ module.exports = {
     return Boolean(env.GITHUB_ACTION);
   },
   configuration({env, cwd}) {
-    const isPr = env.GITHUB_EVENT_NAME === 'pull_request';
+    const isPr = env.GITHUB_EVENT_NAME === 'pull_request' || env.GITHUB_EVENT_NAME === 'pull_request_target';
     const branch = parseBranch(env.GITHUB_REF);
 
     return {

--- a/test/services/github.test.js
+++ b/test/services/github.test.js
@@ -67,6 +67,34 @@ test('PR - with event.json file', t => {
   );
 });
 
+test('PR - target', t => {
+  const eventFile = tempy.file({extension: 'json'});
+  const event = {pull_request: {number: '10', base: {ref: 'refs/heads/master'}}};
+  fs.writeFileSync(eventFile, JSON.stringify(event));
+
+  t.deepEqual(
+    github.configuration({
+      env: {
+        ...env,
+        GITHUB_EVENT_NAME: 'pull_request_target',
+        GITHUB_REF: 'refs/heads/pr-branch',
+        GITHUB_EVENT_PATH: eventFile,
+      },
+    }),
+    {
+      name: 'GitHub Actions',
+      service: 'github',
+      commit: '1234',
+      branch: 'master',
+      isPr: true,
+      prBranch: 'pr-branch',
+      pr: '10',
+      root: '/workspace',
+      slug: 'owner/repo',
+    }
+  );
+});
+
 test('PR - with event.json file and short branch name', t => {
   const eventFile = tempy.file({extension: 'json'});
   const event = {pull_request: {number: '10', base: {ref: 'master'}}};


### PR DESCRIPTION
Github has introduced an additional event [pull_request_target](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target) which is also triggered for pull requests. 
As of now `env-ci` does not respect this event type. 